### PR TITLE
Make role MacOS compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: '2.7'
 # Spin off separate builds for each of the following versions of Ansible
 env:
   - ANSIBLE_VERSION=2.0.2
-  - ANSIBLE_VERSION=2.2.0
+  - ANSIBLE_VERSION=2.3.0
 
 # Require the standard build environment
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -o Dpkg::Options::='--force-confold' --force-yes -y docker-engine
+  - sudo apt-get install -o Dpkg::Options::='--force-confold' --force-yes -y docker-ce
 
 install:
   # Install Ansible

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 language: python
 python: '2.7'
 
+# Test the build on separate OS
+os: 
+  - linux
+  - osx
+
 # Spin off separate builds for each of the following versions of Ansible
 env:
   - ANSIBLE_VERSION=2.0.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: python
 python: '2.7'
 
 # Test the build on separate OS
-os:
-  - linux
-  - osx
+# os:
+#   - linux
+#   - osx
 
 # Spin off separate builds for each of the following versions of Ansible
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: '2.7'
 
 # Test the build on separate OS
-os: 
+os:
   - linux
   - osx
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,9 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - xenial
+  - name: MacOS
+    versions:
+    - Sierra 10.12.5
   galaxy_tags:
     - code
 dependencies: []

--- a/molecule.yml
+++ b/molecule.yml
@@ -14,6 +14,5 @@ docker:
     - name: ansible-role-visual-studio-code-extensions-ubuntu-xenial
       image: ubuntu
       image_version: '16.04'
-
 verifier:
   name: testinfra

--- a/tasks/MacOSX.yml
+++ b/tasks/MacOSX.yml
@@ -1,0 +1,37 @@
+---
+- name: create config directories for users
+  become: yes
+  file:
+    path: "~{{ item.0.username }}/.config"
+    state: directory
+    owner: "{{ item.0.username }}"
+    group: admin
+    mode: 'u=rwx,go=r'
+  with_subelements:
+    - "{{ users }}"
+    - visual_studio_code_extensions
+    - skip_missing: yes
+
+- name: create Visual Studio Code directories for users
+  become: yes
+  file:
+    path: "~{{ item.0.username }}/.config/Code/User"
+    state: directory
+    owner: "{{ item.0.username }}"
+    group: admin
+    mode: 'u=rwx,go='
+  with_subelements:
+    - "{{ users }}"
+    - visual_studio_code_extensions
+    - skip_missing: yes
+
+- name: install extensions
+  become: yes
+  become_user: "{{ item.0.username }}"
+  command: "code --install-extension '{{ item.1 }}'"
+  with_subelements:
+    - "{{ users }}"
+    - visual_studio_code_extensions
+    - skip_missing: yes
+  register: vscode_result
+  changed_when: "'already installed' not in vscode_result.stdout"

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -1,0 +1,48 @@
+---
+- name: install extension cli dependencies (apt)
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - gconf2
+    - libasound2
+    - libgtk2.0-0
+    - libxss1
+  when: ansible_pkg_mgr == 'apt'
+
+- name: create config directories for users
+  become: yes
+  file:
+    path: "~{{ item.0.username }}/.config"
+    state: directory
+    owner: "{{ item.0.username }}"
+    group: "{{ item.0.username }}"
+    mode: 'u=rwx,go=r'
+  with_subelements:
+    - "{{ users }}"
+    - visual_studio_code_extensions
+    - skip_missing: yes
+
+- name: create Visual Studio Code directories for users
+  become: yes
+  file:
+    path: "~{{ item.0.username }}/.config/Code/User"
+    state: directory
+    owner: "{{ item.0.username }}"
+    group: "{{ item.0.username }}"
+    mode: 'u=rwx,go='
+  with_subelements:
+    - "{{ users }}"
+    - visual_studio_code_extensions
+    - skip_missing: yes
+
+- name: install extensions
+  become: yes
+  become_user: "{{ item.0.username }}"
+  command: "code --install-extension '{{ item.1 }}'"
+  with_subelements:
+    - "{{ users }}"
+    - visual_studio_code_extensions
+    - skip_missing: yes
+  register: vscode_result
+  changed_when: "'already installed' not in vscode_result.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,48 +1,6 @@
 ---
-- name: install extension cli dependencies (apt)
-  apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - gconf2
-    - libasound2
-    - libgtk2.0-0
-    - libxss1
-  when: ansible_pkg_mgr == 'apt'
+- include: MacOSX.yml
+  when: "ansible_distribution == 'MacOSX'"
 
-- name: create config directories for users
-  become: yes
-  file:
-    path: "~{{ item.0.username }}/.config"
-    state: directory
-    owner: "{{ item.0.username }}"
-    group: "{{ item.0.username }}"
-    mode: 'u=rwx,go=r'
-  with_subelements:
-    - "{{ users }}"
-    - visual_studio_code_extensions
-    - skip_missing: yes
-
-- name: create Visual Studio Code directories for users
-  become: yes
-  file:
-    path: "~{{ item.0.username }}/.config/Code/User"
-    state: directory
-    owner: "{{ item.0.username }}"
-    group: "{{ item.0.username }}"
-    mode: 'u=rwx,go='
-  with_subelements:
-    - "{{ users }}"
-    - visual_studio_code_extensions
-    - skip_missing: yes
-
-- name: install extensions
-  become: yes
-  become_user: "{{ item.0.username }}"
-  command: "code --install-extension '{{ item.1 }}'"
-  with_subelements:
-    - "{{ users }}"
-    - visual_studio_code_extensions
-    - skip_missing: yes
-  register: vscode_result
-  changed_when: "'already installed' not in vscode_result.stdout"
+- include: default.yml
+  when: "ansible_distribution != 'MacOSX'"

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -13,3 +13,8 @@ def test_visual_studio_code(Command, extension):
     output = Command.check_output('sudo --user test_usr -H code %s %s',
                                   '--install-extension', extension)
     assert 'already installed' in output
+
+def test_visual_studio_code_extensions(Command):
+    output = Command.check_output('code --list-extensions')
+    assert 'donjayamanne.python' in output
+

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -16,6 +16,6 @@ def test_visual_studio_code(Command, extension):
 
 
 def test_visual_studio_code_extensions(Command):
-    output = Command.check_output('sudo --user test_user -H code %s',
+    output = Command.check_output('sudo --user test_usr -H code %s',
                                   '--list-extensions')
     assert 'donjayamanne.python' in output

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -17,3 +17,4 @@ def test_visual_studio_code(Command, extension):
 def test_visual_studio_code_extensions(Command):
     output = Command.check_output('code --list-extensions')
     assert 'donjayamanne.python' in output
+    

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -16,5 +16,6 @@ def test_visual_studio_code(Command, extension):
 
 
 def test_visual_studio_code_extensions(Command):
-    output = Command.check_output('sudo --user test_user -H code --list-extensions')
+    output = Command.check_output('sudo --user test_user -H code %s',
+                                  '--list-extensions')
     assert 'donjayamanne.python' in output

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -17,4 +17,3 @@ def test_visual_studio_code(Command, extension):
 def test_visual_studio_code_extensions(Command):
     output = Command.check_output('code --list-extensions')
     assert 'donjayamanne.python' in output
-    

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -17,4 +17,3 @@ def test_visual_studio_code(Command, extension):
 def test_visual_studio_code_extensions(Command):
     output = Command.check_output('code --list-extensions')
     assert 'donjayamanne.python' in output
-

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -14,6 +14,7 @@ def test_visual_studio_code(Command, extension):
                                   '--install-extension', extension)
     assert 'already installed' in output
 
+
 def test_visual_studio_code_extensions(Command):
     output = Command.check_output('code --list-extensions')
     assert 'donjayamanne.python' in output

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -16,5 +16,5 @@ def test_visual_studio_code(Command, extension):
 
 
 def test_visual_studio_code_extensions(Command):
-    output = Command.check_output('code --list-extensions')
+    output = Command.check_output('sudo --user test_user -H code --list-extensions')
     assert 'donjayamanne.python' in output


### PR DESCRIPTION
Modified the tasks main.yml file. The role is now compatible with MacOSX. 
There are no changes required in the roles configuration. Based on the underlying operating system where the playbook is running the appropriate task file will be executed.