### PR TITLE
Permit the user group to be unspecified

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,12 @@
 - name: set default user group for SUSE
   set_fact:
     visual_studio_code_extensions_user_group_name: users
-  when: "ansible_os_family == 'Suse' and visual_studio_code_extensions_user_group_name in (None, '', omit)"
+  when: "ansible_os_family == 'Suse' and visual_studio_code_extensions_user_group_name in (None, '')"
 
 - name: set default user group for MacOSX
   set_fact:
     visual_studio_code_extensions_user_group_name: admin
-  when: "ansible_distribution == 'MacOSX' and visual_studio_code_extensions_user_group_name in (None, '', omit)"
+  when: "ansible_distribution == 'MacOSX' and visual_studio_code_extensions_user_group_name in (None, '')"
 
 - name: create config directories for users
   become: yes
@@ -26,7 +26,7 @@
     path: "~{{ item.0.username }}/.config"
     state: directory
     owner: "{{ item.0.username }}"
-    group: "{{ (visual_studio_code_extensions_user_group_name not in (None, '', omit)) | ternary(visual_studio_code_extensions_user_group_name, item.0.username) }}"
+    group: "{{ (visual_studio_code_extensions_user_group_name not in (None, '')) | ternary(visual_studio_code_extensions_user_group_name, item.0.username) }}"
     mode: 'u=rwx,go=r'
   with_subelements:
     - "{{ users }}"
@@ -39,7 +39,7 @@
     path: "~{{ item.0.username }}/.config/Code/User"
     state: directory
     owner: "{{ item.0.username }}"
-    group: "{{ (visual_studio_code_extensions_user_group_name not in (None, '', omit)) | ternary(visual_studio_code_extensions_user_group_name, item.0.username) }}"
+    group: "{{ (visual_studio_code_extensions_user_group_name not in (None, '')) | ternary(visual_studio_code_extensions_user_group_name, item.0.username) }}"
     mode: 'u=rwx,go='
   with_subelements:
     - "{{ users }}"


### PR DESCRIPTION
You can now specify `omit` to leave the user group as unspecified and get the default group assigned by the OS.