### PR TITLE
Restored command line dependencies install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: install extension cli dependencies (apt)
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - gconf2
+    - libasound2
+    - libgtk2.0-0
+    - libxss1
+  when: ansible_pkg_mgr == 'apt'
+
 - name: set default user group for SUSE
   set_fact:
     visual_studio_code_extensions_user_group_name: users


### PR DESCRIPTION
This is necessary with the Apt package if you haven't installed XWindows yet.

This reverts commit 83e1cf2dde9d4a64ef911db3c288b370793a3502.