### PR TITLE
Increased minimum Ansible version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,16 @@ python: '2.7'
 matrix:
   include:
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=centos
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=default
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=fedora
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=opensuse
     - env:
         - ANSIBLE_VERSION=2.6.3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Role to install extensions for the
 Requirements
 ------------
 
-* Ansible >= 2.3
+* Ansible >= 2.4
 
 * OS
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing Visual Studio Code extensions.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports version 2.3 and earlier.