### PR TITLE
Added vscode tag to metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,5 +20,6 @@ galaxy_info:
         - 10.12
   galaxy_tags:
     - code
+    - vscode
     - development
 dependencies: []


### PR DESCRIPTION
An abbreviation of Visual Studio Code.