### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -18,15 +18,14 @@
     - name: install dependencies (Debian)
       become: yes
       apt:
-        name: '{{ item }}'
+        name:
+          - ca-certificates
+          - apt-transport-https
+          - gconf2
+          - libasound2
+          - libgtk2.0-0
+          - libxss1
         state: present
-      with_items:
-        - ca-certificates
-        - apt-transport-https
-        - gconf2
-        - libasound2
-        - libgtk2.0-0
-        - libxss1
       when: ansible_pkg_mgr == 'apt'
 
     - name: install apt key (Debian)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,12 @@
 ---
 - name: install extension cli dependencies (apt)
   apt:
-    name: '{{ item }}'
+    name:
+      - gconf2
+      - libasound2
+      - libgtk2.0-0
+      - libxss1
     state: present
-  with_items:
-    - gconf2
-    - libasound2
-    - libgtk2.0-0
-    - libxss1
   when: ansible_pkg_mgr == 'apt'
 
 - name: install extension cli dependencies (dnf)


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'gconf2', u'libasound2',
 u'libgtk2.0-0', u'libxss1']` and remove the loop. This feature will be removed
 in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```