### PR TITLE
Added missing test dependency

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -24,6 +24,7 @@
           - gconf2
           - libasound2
           - libgtk2.0-0
+          - libx11-xcb1
           - libxss1
           - gnupg2
         state: present


### PR DESCRIPTION
Latest VS Code requires `libx11-xcb1` to use the CLI now.