### PR TITLE
Add pkg-mgr vars for Homebrew

### DIFF
--- a/vars/pkg-mgr/homebrew.yml
+++ b/vars/pkg-mgr/homebrew.yml
@@ -1,0 +1,3 @@
+---
+# Dependencies for Visual Studio Code cli
+visual_studio_code_extensions_dependencies: []


### PR DESCRIPTION
Add an empty `visual_studio_code_extensions_dependencies` for macOS hosts using Homebrew, which do not require any additional packages.