### PR TITLE
Increased minimum Ansible version to 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,27 +15,27 @@ env:
 jobs:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=centos
       python: '2.7'
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=default
       python: '2.7'
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=ubuntu-min
       python: '2.7'
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=fedora
       python: '2.7'
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=opensuse
       python: '2.7'
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=python3
       python: '3.6'
     - env:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Role to install extensions for the
 Requirements
 ------------
 
-* Ansible >= 2.7
+* Ansible >= 2.8
 
 * OS
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing Visual Studio Code extensions.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.8.