### PR TITLE
Added missing Ubuntu, Fedora and openSUSE dependencies

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+  - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -15,20 +15,16 @@
         - test_usr2
         - test_usr3
 
-    - name: install dependencies (Debian)
-      become: yes
-      apt:
-        name:
-          - ca-certificates
-          - apt-transport-https
-          - gconf2
-          - libasound2
-          - libgtk2.0-0
-          - libx11-xcb1
-          - libxss1
-          - gnupg2
+    - name: include package manager specific vars
+      with_first_found:
+        - '../../vars/pkg-mgr/{{ ansible_pkg_mgr }}.yml'
+        - ../../vars/pkg-mgr/default.yml
+      include_vars: '{{ item }}'
+
+    - name: install extension cli dependencies
+      package:
+        name: '{{ visual_studio_code_extensions_dependencies }}'
         state: present
-      when: ansible_pkg_mgr == 'apt'
 
     - name: install apt key (Debian)
       apt_key:

--- a/vars/pkg-mgr/dnf.yml
+++ b/vars/pkg-mgr/dnf.yml
@@ -1,5 +1,7 @@
 ---
 # Dependencies for Visual Studio Code cli
 visual_studio_code_extensions_dependencies:
+  - libdrm
   - libX11-xcb
+  - mesa-libgbm
   - which

--- a/vars/pkg-mgr/zypper.yml
+++ b/vars/pkg-mgr/zypper.yml
@@ -1,14 +1,7 @@
 ---
 # Dependencies for Visual Studio Code cli
 visual_studio_code_extensions_dependencies:
-  - apt-transport-https
-  - ca-certificates
-  - gconf2
-  - gnupg2
-  - libasound2
   - libdrm2
   - libgbm1
-  - libgtk2.0-0
-  - libx11-xcb1
   - libxcb-dri3-0
-  - libxss1
+  - which


### PR DESCRIPTION
It seems they're no-longer installed as dependencies of the VS Code package itself.