### PR TITLE
Homebrew (MacOS) package requirements

### DIFF
--- a/vars/pkg-mgr/homebrew.yml
+++ b/vars/pkg-mgr/homebrew.yml
@@ -1,4 +1,3 @@
 ---
 # Dependencies for Visual Studio Code cli
 visual_studio_code_extensions_dependencies:
-  - gnu-which

--- a/vars/pkg-mgr/homebrew.yml
+++ b/vars/pkg-mgr/homebrew.yml
@@ -1,0 +1,4 @@
+---
+# Dependencies for Visual Studio Code cli
+visual_studio_code_extensions_dependencies:
+  - gnu-which


### PR DESCRIPTION
Using this on MacOS Big Sur with Homebrew doesn't require any additional packages to and would error out as the default search for the `which` package fails as it is called `gnu-which` in Homebrew.

Deployed twice on a fresh Big Sur installation using the empty requirements file for Homebrew and both worked as expected.