### PR TITLE
Increased minimum CentOS version to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - '2.8.16'
           - '2.9.1'
         molecule-scenario:
-          # - centos
+          - centos
           - default
           - ubuntu-min
           - fedora

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requirements
 
           * CentOS
 
-              * 7
+              * 8
 
           * Fedora
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
+        - 8
     - name: Ubuntu
       versions:
         - xenial

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-visual-studio-code-extensions-centos
-    image: centos:7
+    image: centos:8
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Necessary for recent Code Insiders builds.