### PR TITLE
remove deprecated `gconf2` from Ubuntu

### DIFF
--- a/vars/pkg-mgr/apt.yml
+++ b/vars/pkg-mgr/apt.yml
@@ -3,7 +3,6 @@
 visual_studio_code_extensions_dependencies:
   - apt-transport-https
   - ca-certificates
-  - gconf2
   - gnupg2
   - libasound2
   - libdrm2


### PR DESCRIPTION
see #119. Remove deprecated `gconf2` package and everything seems to work fine.