### PR TITLE
Dropped support for Ubuntu Bionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Requirements
 
           * Ubuntu
 
-              * Bionic (18.04)
               * Focal (20.04)
 
       * RedHat Family

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
         - 8
     - name: Ubuntu
       versions:
-        - bionic
         - focal
     - name: Fedora
       versions:

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-visual-studio-code-extensions-ubuntu-min
-    image: ubuntu:18.04
+    image: ubuntu:20.04
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Bionic.